### PR TITLE
Append a newline to response block text when splitting

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1083,11 +1083,15 @@ mod test {
         );
 
         parser_test!(
-            just_request_ends_with_multiple_newlines,
+            response_with_no_newline,
             textwrap::dedent(
                 "
                 ```%request
                 GET http://example.com HTTP/1.1
+                ```
+
+                ```%response
+                HTTP/1.1 200 OK
                 ```
                 "
             ),
@@ -1103,7 +1107,16 @@ mod test {
                     },
                     1..48
                 ),
-                response: None,
+                response: Some((
+                    HttpResponse {
+                        http_version: HttpVersion::one_point_one(),
+                        status_code: HttpStatusCode::new(200),
+                        status_text: "OK".to_owned(),
+                        headers: HashMap::default(),
+                        body: Some("".to_string())
+                    },
+                    50..82
+                )),
                 refs: vec![],
             })
         );
@@ -1215,7 +1228,7 @@ mod test {
                         status_code: HttpStatusCode::new(200),
                         status_text: "OK".to_string(),
                         headers: HashMap::new(),
-                        body: Some("{{?expected_response_body}}\n\n".to_string())
+                        body: Some("{{?expected_response_body}}\n\n\n".to_string())
                     },
                     336..398
                 )),
@@ -1325,7 +1338,7 @@ mod test {
                         status_code: HttpStatusCode::new(200),
                         status_text: "OK".to_owned(),
                         headers: HashMap::default(),
-                        body: Some("".to_owned())
+                        body: Some("\n".to_owned())
                     },
                     575..608
                 )),

--- a/parser/src/splitter.rs
+++ b/parser/src/splitter.rs
@@ -61,7 +61,7 @@ pub fn split(input: &str) -> Result<RequestFileSplitUp, Vec<Spanned<ReqlangError
 
     let response: Option<Spanned<String>> = response.map(|response| {
         (
-            format!("{response}\n"),
+            format!("{response}\n\n"),
             response_span.expect("should have a response span from the markdown parsing"),
         )
     });
@@ -147,7 +147,7 @@ mod tests {
         assert_eq!(
             Ok(RequestFileSplitUp {
                 request: (String::from("REQUEST\n\n"), 1..24),
-                response: Some((String::from("RESPONSE\n"), 26..51)),
+                response: Some((String::from("RESPONSE\n\n"), 26..51)),
                 config: None
             }),
             output
@@ -177,7 +177,7 @@ mod tests {
         assert_eq!(
             Ok(RequestFileSplitUp {
                 request: (String::from("REQUEST\n\n"), 24..47),
-                response: Some((String::from("RESPONSE\n"), 49..74)),
+                response: Some((String::from("RESPONSE\n\n"), 49..74)),
                 config: Some((String::from("CONFIG"), 1..22))
             }),
             output

--- a/parser/src/templater.rs
+++ b/parser/src/templater.rs
@@ -188,7 +188,7 @@ HTTP/1.1 200 OK
                 status_code: HttpStatusCode::new(200),
                 status_text: "OK".to_string(),
                 headers: HashMap::new(),
-                body: Some("expected_response_body_value\n\n".to_string())
+                body: Some("expected_response_body_value\n\n\n".to_string())
             }),
         })
     );

--- a/reqlang/src/lib.rs
+++ b/reqlang/src/lib.rs
@@ -78,7 +78,7 @@ mod tests {
                         status_code: HttpStatusCode::new(200),
                         status_text: "OK".to_string(),
                         headers: HashMap::new(),
-                        body: Some("{{?expected_response_body}}\n\n".to_string())
+                        body: Some("{{?expected_response_body}}\n\n\n".to_string())
                     },
                     310..372
                 )),
@@ -189,7 +189,7 @@ mod tests {
                     status_code: HttpStatusCode::new(200),
                     status_text: "OK".to_string(),
                     headers: HashMap::new(),
-                    body: Some("expected_response_body_value\n\n".to_string())
+                    body: Some("expected_response_body_value\n\n\n".to_string())
                 }),
             }),
             templated_reqfile


### PR DESCRIPTION
This is a temporary fix to allow for response blocks without a trailing newline