### PR TITLE
Show the parse result object instead of the parsed request file

### DIFF
--- a/reqlang-web-client/client/src/App.tsx
+++ b/reqlang-web-client/client/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import "./App.css";
 import Uploader from "./components/Uploader";
 import { useFileStore } from "./stores/file";
-import { ParsedRequestFile } from "reqlang-types";
+import { ParseResult } from "reqlang-types";
 
 function App() {
   const fileStore = useFileStore();
@@ -17,8 +17,7 @@ function App() {
         });
 
         if (response.ok) {
-          const parsedRequestFile =
-            (await response.json()) as ParsedRequestFile;
+          const parsedRequestFile = (await response.json()) as ParseResult;
 
           fileStore.setParsedFile(parsedRequestFile);
         }

--- a/reqlang-web-client/client/src/stores/file.ts
+++ b/reqlang-web-client/client/src/stores/file.ts
@@ -1,4 +1,4 @@
-import { ParsedRequestFile } from "reqlang-types";
+import { ParseResult } from "reqlang-types";
 import { create } from "zustand";
 
 type LoadedFile = {
@@ -8,15 +8,15 @@ type LoadedFile = {
 
 interface FileState {
   file: LoadedFile | null;
-  parsedFile: ParsedRequestFile | null;
+  parsedFile: ParseResult | null;
 
   setFile: (file: LoadedFile) => void;
-  setParsedFile: (file: ParsedRequestFile) => void;
+  setParsedFile: (file: ParseResult) => void;
 }
 
 export const useFileStore = create<FileState>()((set) => ({
   file: null,
   parsedFile: null,
   setFile: (file: LoadedFile) => set({ file }),
-  setParsedFile: (file: ParsedRequestFile) => set({ parsedFile: file }),
+  setParsedFile: (file: ParseResult) => set({ parsedFile: file }),
 }));


### PR DESCRIPTION
The parse result object is suited for reqlang clients as it handles things like prompt names