### PR TITLE
Only open web client in browser if a browser is available

### DIFF
--- a/reqlang-web-client/src/main.rs
+++ b/reqlang-web-client/src/main.rs
@@ -38,7 +38,9 @@ async fn main() -> Result<(), Error> {
 
     eprintln!("reqlang-web-client: {url}");
 
-    webbrowser::open(&url)?;
+    if webbrowser::Browser::is_available() {
+        webbrowser::open(&url)?;
+    }
 
     let app = Router::new()
         .route("/parse", post(parse_request_file))


### PR DESCRIPTION
This will help in situations like docker where there isn't a web browser