### PR TITLE
Fix bug where single char template references wouldn't be counted

### DIFF
--- a/examples/valid/single_chararacter_prompt_reference.reqlang
+++ b/examples/valid/single_chararacter_prompt_reference.reqlang
@@ -1,0 +1,8 @@
+```%config
+[[prompts]]
+name = "a"
+```
+
+```%request
+GET https://example.com/{{?a}} HTTP/1.1
+```

--- a/examples/valid/single_chararacter_secret_reference.reqlang
+++ b/examples/valid/single_chararacter_secret_reference.reqlang
@@ -1,0 +1,7 @@
+```%config
+secrets = ["a"]
+```
+
+```%request
+GET https://example.com/{{!a}} HTTP/1.1
+```

--- a/examples/valid/single_chararacter_variable_reference.reqlang
+++ b/examples/valid/single_chararacter_variable_reference.reqlang
@@ -1,0 +1,11 @@
+```%config
+[[vars]]
+name = "a"
+
+[envs.test]
+a = "123"
+```
+
+```%request
+GET https://example.com/{{:a}} HTTP/1.1
+```

--- a/reqlang/src/parser.rs
+++ b/reqlang/src/parser.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-pub const TEMPLATE_REFERENCE_PATTERN: &str = r"\{\{([:?!@]{1})([a-zA-Z][_a-zA-Z0-9.]+)\}\}";
+pub const TEMPLATE_REFERENCE_PATTERN: &str = r"\{\{([:?!@]{1})([a-zA-Z][_a-zA-Z0-9.]*)\}\}";
 
 static FORBIDDEN_REQUEST_HEADER_NAMES: &[&str] = &[
     "host",


### PR DESCRIPTION
This was a bug in the regex pattern for template references

Fixes #105 