### PR TITLE
Update the export to HTTP message to use CRLF (\r\n) instead of LF (\n)

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -308,7 +308,7 @@ mod cli_integration_tests {
 
         assert_success!(
             assert,
-            Some("GET https://httpbin.org/status/200 HTTP/1.1\n\n"),
+            Some("GET https://httpbin.org/status/200 HTTP/1.1\r\n\n"),
             None::<String>
         );
     }

--- a/reqlang/src/export.rs
+++ b/reqlang/src/export.rs
@@ -211,14 +211,14 @@ mod test {
         format_to_http_get_request,
         HttpRequest::get("/", "1.1", vec![]),
         RequestFormat::HttpMessage,
-        "GET / HTTP/1.1\n"
+        "GET / HTTP/1.1\r\n"
     );
 
     export_test!(
         format_to_http_post_request,
         HttpRequest::post("/", "1.1", vec![], Some("[1, 2, 3]\n")),
         RequestFormat::HttpMessage,
-        "POST / HTTP/1.1\n\n[1, 2, 3]\n"
+        "POST / HTTP/1.1\r\n\r\n[1, 2, 3]\n"
     );
 
     export_response_test!(

--- a/reqlang/src/types/http.rs
+++ b/reqlang/src/types/http.rs
@@ -144,13 +144,13 @@ impl Display for HttpRequest {
             None
         } else {
             Some(format!(
-                "{}\n",
+                "{}\r\n",
                 self.headers
                     .clone()
                     .into_iter()
                     .map(|x| format!("{}: {}", x.0, x.1))
                     .collect::<Vec<String>>()
-                    .join("\n")
+                    .join("\r\n")
                     .trim_end()
             ))
         };
@@ -161,15 +161,15 @@ impl Display for HttpRequest {
             .and_then(|x| if x.is_empty() { None } else { Some(x) });
 
         let the_rest = match (&headers, &body) {
-            (Some(headers), Some(body)) => format!("{headers}\n{body}"),
+            (Some(headers), Some(body)) => format!("{headers}\r\n{body}"),
             (Some(headers), None) => headers.to_string(),
-            (None, Some(body)) => format!("\n{body}"),
+            (None, Some(body)) => format!("\r\n{body}"),
             (None, None) => String::new(),
         };
 
         write!(
             f,
-            "{} {} HTTP/{}\n{}",
+            "{} {} HTTP/{}\r\n{}",
             self.verb, self.target, self.http_version, the_rest
         )
     }

--- a/reqlang/src/types/mod.rs
+++ b/reqlang/src/types/mod.rs
@@ -780,8 +780,8 @@ mod tests {
 
             assert_eq!(
                 concat!(
-                    "POST / HTTP/1.1\n",
-                    "host: https://example.com\n\n",
+                    "POST / HTTP/1.1\r\n",
+                    "host: https://example.com\r\n\r\n",
                     "[1, 2, 3]\n"
                 ),
                 format!("{req}"),
@@ -797,7 +797,7 @@ mod tests {
             );
 
             assert_eq!(
-                concat!("GET / HTTP/1.1\n", "host: https://example.com\n"),
+                concat!("GET / HTTP/1.1\r\n", "host: https://example.com\r\n"),
                 format!("{req}"),
             );
         }
@@ -806,7 +806,7 @@ mod tests {
         fn get_request_no_headers() {
             let req = HttpRequest::get("/", "1.1", Vec::default());
 
-            assert_eq!("GET / HTTP/1.1\n", format!("{req}"));
+            assert_eq!("GET / HTTP/1.1\r\n", format!("{req}"));
         }
     }
 }


### PR DESCRIPTION
#136 

